### PR TITLE
corrected typo in question.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -23,7 +23,7 @@ body:
           required: true
         - label: I've searched the [docs](https://github.com/Lissy93/git-into-open-source/tree/main/.github) for an answer
           required: true
-        - label: I agree to follow thr [Code of Conduct](https://github.com/Lissy93/git-into-open-source/blob/main/.github/CODE_OF_CONDUCT.md)
+        - label: I agree to follow the [Code of Conduct](https://github.com/Lissy93/git-into-open-source/blob/main/.github/CODE_OF_CONDUCT.md)
           required: true
   - type: markdown
     attributes:


### PR DESCRIPTION
Review Requested. At Line 26 of the question.yml file, there is a typo in "thr", I have corrected the spelling to the word "the".

<!-- Select a category -->
<!--  Options: Name addition / resource addition / docs update / website update / lib update / other (please specify) -->
**PR Type:** ___

<!-- If you are adding a resource or link, that you are affiliated with in any way, please declare your association for transparency -->
**Affiliation:** N/A

<!-- If your PR relates to an open issue, please reference it here -->
**Ticket:** N/A

<!-- Finally, check the boxes below with an 'X' to confirm you've read the docs --> 
**Checklist:**
- [x] I've read Contributing Guidelines
- [x] I agree to follow the Code of Conduct

<!--Thanks for contributing to git-into-open-source! You'll receive a response within the next 48-hours  -->
